### PR TITLE
Upgraded Symfony/Console requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     },
     "require": {
-        "php": ">=5.3",
-        "symfony/console": "2.2.*"
+        "php": ">=5.3.3",
+        "symfony/console": "~2.3"
     },
     "bin": [
         "bin/clover-dump"


### PR DESCRIPTION
I've changed Symfony2 Console component required version so it can be installed with either with 2.7 version od Symfony Console.